### PR TITLE
Update placeholder grey to the one used in the frontend library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-header-search",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Accessibile autocomplete implementation for NHS.UK search",
   "main": "dist/header-search.js",
   "style": "dist/header-search.scss",

--- a/src/scss/header-search.scss
+++ b/src/scss/header-search.scss
@@ -80,7 +80,7 @@
     }
 
     &::placeholder {
-      color: $color_nhsuk-grey-2;
+      color: $color_nhsuk-grey-1;
       font-size: $nhsuk-base-font-size;
     }
   }


### PR DESCRIPTION
Use a darker grey for the placeholder as per the frontend library - https://github.com/nhsuk/nhsuk-frontend/blob/6a0997f758ff4d449f71ecc4ed66cef4287bbe99/packages/components/header/_header.scss#L231

This fixes colour contrast accessibility issue.