### PR TITLE
Update placeholder grey to the one used in the frontend library 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-header-search",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10505,6 +10505,7 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -10523,6 +10524,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -10555,6 +10557,7 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -10567,6 +10570,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -10622,6 +10626,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -10631,6 +10636,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -10642,6 +10648,7 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -10675,6 +10682,7 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-header-search",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Accessibile autocomplete implementation for NHS.UK search",
   "main": "dist/header-search.js",
   "style": "dist/header-search.scss",

--- a/src/scss/header-search.scss
+++ b/src/scss/header-search.scss
@@ -25,19 +25,35 @@
   }
 }
 
+/* duplicate of .nhsuk-search__input in _header.scss, for non javascript version */
+.autocomplete__input {
+  -webkit-appearance: listbox; // sass-lint:disable-line prefixes /* [2] */
+  border-bottom-left-radius: $nhsuk-border-radius;
+  border-bottom-right-radius: 0;
+  border-right: 0;
+  border-top-left-radius: $nhsuk-border-radius;
+  border-top-right-radius: 0;
+
+  &:focus {
+    box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-color;
+    outline: $nhsuk-focus-width solid transparent;
+    outline-offset: $nhsuk-focus-width;
+  }
+
+  &::placeholder {
+    color: $color_nhsuk-grey-1;
+    font-size: $nhsuk-base-font-size;
+  }
+
+}
+
 @include mq($until: tablet) {
   /* duplicate of .nhsuk-search__input in _header.scss, for non javascript version */
   .autocomplete__input {
     -ms-flex-positive: 2; /* [1] */
-    -webkit-appearance: listbox; // sass-lint:disable-line prefixes /* [2] */
     border-bottom: 1px solid $color_nhsuk-grey-3;
-    border-bottom-left-radius: $nhsuk-border-radius;
-    border-bottom-right-radius: 0;
     border-left: 1px solid $color_nhsuk-grey-3;
-    border-right: 0;
     border-top: 1px solid $color_nhsuk-grey-3;
-    border-top-left-radius: $nhsuk-border-radius;
-    border-top-right-radius: 0;
     flex-grow: 2;
     font-size: inherit;
     height: 52px; /* [3] */
@@ -48,9 +64,6 @@
 
     &:focus {
       border: $nhsuk-focus-width solid $nhsuk-focus-text-color;
-      box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-color;
-      outline: $nhsuk-focus-width solid transparent;
-      outline-offset: $nhsuk-focus-width;
       padding: 0 13px; /* [10] */
     }
   }
@@ -59,13 +72,7 @@
 @include mq($from: tablet) {
   /* duplicate of .nhsuk-search__input in _header.scss, for non javascript version */
   .autocomplete__input {
-    -webkit-appearance: listbox; // sass-lint:disable-line prefixes /* [2] */
     border: 1px solid $color_nhsuk-white;
-    border-bottom-left-radius: $nhsuk-border-radius;
-    border-bottom-right-radius: 0;
-    border-right: 0;
-    border-top-left-radius: $nhsuk-border-radius;
-    border-top-right-radius: 0;
     font-size: $nhsuk-base-font-size;
     height: 40px; /* [3] */
     padding: 0 12px; /* [9] */
@@ -73,9 +80,6 @@
 
     &:focus {
       border: 2px solid $nhsuk-focus-text-color;
-      box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-color;
-      outline: $nhsuk-focus-width solid transparent;
-      outline-offset: $nhsuk-focus-width;
       padding: 0 11px; /* [10] */
     }
 


### PR DESCRIPTION
The previous update was only `mq($from: tablet)`, the mobile search input was still a accessibility fail. I've updated this to have a generic `.autocomplete__input` selector and removed styles that were duplicated on `mq($until: tablet)` and `mq($from: tablet)` to help clean things up. 