### PR TITLE
Add Owasp scanner in Github release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -29,11 +32,32 @@ jobs:
       - name: Build release artifact
         run: npm run build
 
+      - name: Depcheck
+        uses: dependency-check/Dependency-Check_Action@main
+        id: Depcheck
+        with:
+          project: 'nhsuk.header-search'
+          path: '.'
+          format: 'HTML'
+          out: 'reports'
+          args: >
+            --failOnCVSS 7 
+            --nodePackageSkipDevDependencies
+            --nodeAuditSkipDevDependencies
+
+      - name: Upload OWAPS results
+        uses: actions/upload-artifact@master
+        with:
+           name: Depcheck report
+           path: ${{github.workspace}}/reports
+
       - name: Get package version
+        if: {{ github.ref == 'ref/tags/*' }}
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
 
       - name: Publish NPM package
+        if: {{ github.ref == 'ref/tags/*' }}
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}


### PR DESCRIPTION
- Add OWASP dependency-check scanner task to release action with result output form in HTML format.